### PR TITLE
Add PDF trimming utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # chirag-hobby-projects
-This repo would contain hobby projects and functions developed by me
+This repo contains hobby projects and utility functions.
+
+## PDF Trimming Utility
+
+`pdf_trim.py` is an interactive utility that extracts a range of pages from a PDF file and saves the result in a preset directory (`trimmed_pdfs` by default).
+
+### Usage
+
+Run the script and follow the prompts:
+
+```bash
+python pdf_trim.py
+```
+
+You will be asked for the PDF path, the start and end page numbers, and optionally an output directory. The resulting PDF will be written to the chosen directory.

--- a/pdf_trim.py
+++ b/pdf_trim.py
@@ -1,0 +1,49 @@
+import os
+from PyPDF2 import PdfReader, PdfWriter
+
+def trim_pdf(source_path: str, start_page: int, end_page: int, output_dir: str = "trimmed_pdfs") -> str:
+    """Trim a PDF from start_page to end_page (inclusive) and save it.
+
+    Args:
+        source_path: Path to the source PDF file.
+        start_page: 1-indexed start page.
+        end_page: 1-indexed end page.
+        output_dir: Directory where the trimmed PDF will be saved.
+
+    Returns:
+        Path to the trimmed PDF.
+    """
+    if start_page < 1 or end_page < start_page:
+        raise ValueError("Invalid page range")
+
+    reader = PdfReader(source_path)
+    num_pages = len(reader.pages)
+
+    start_index = start_page - 1
+    end_index = min(end_page, num_pages)
+
+    writer = PdfWriter()
+    for page_num in range(start_index, end_index):
+        writer.add_page(reader.pages[page_num])
+
+    os.makedirs(output_dir, exist_ok=True)
+    output_path = os.path.join(output_dir, os.path.basename(source_path))
+    with open(output_path, "wb") as f:
+        writer.write(f)
+
+    return output_path
+
+
+def main():
+    """Prompt the user for input and trim the PDF."""
+    pdf_path = input("Enter the path to the PDF file: ").strip()
+    start_page = int(input("Enter the start page number (1-indexed): "))
+    end_page = int(input("Enter the end page number (inclusive, 1-indexed): "))
+    output_dir = input("Output directory [trimmed_pdfs]: ").strip() or "trimmed_pdfs"
+
+    output = trim_pdf(pdf_path, start_page, end_page, output_dir)
+    print(f"Trimmed PDF saved to: {output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `pdf_trim.py` to trim ranges of pages from PDFs
- document how to use the utility in the README
- change tool to prompt for input instead of command line flags

## Testing
- `python pdf_trim.py` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*
- `pip install PyPDF2` *(fails: Could not find a version that satisfies the requirement)*


------
https://chatgpt.com/codex/tasks/task_e_6851b5d73be883239eff9971071f258a